### PR TITLE
Ensure cache is fully flushed at the end of the test run

### DIFF
--- a/tests/phpunit/test-cache.php
+++ b/tests/phpunit/test-cache.php
@@ -807,8 +807,9 @@ class CacheTest extends WP_UnitTestCase {
 	static function tearDownAfterClass() {
 		parent::tearDownAfterClass();
 		// @codingStandardsIgnoreStart
-		$GLOBALS['wpdb']->query( "TRUNCATE TABLE lcache_events" );
-		$GLOBALS['wpdb']->query( "TRUNCATE TABLE lcache_tags" );
+		$table_prefix = $GLOBALS['table_prefix'] ;
+		$GLOBALS['wpdb']->query( "TRUNCATE TABLE " . $table_prefix . "lcache_events" );
+		$GLOBALS['wpdb']->query( "TRUNCATE TABLE " . $table_prefix . "lcache_tags" );
 		unlink( ABSPATH . 'wp-content/object-cache.php' );
 		// @codingStandardsIgnoreEnd
 	}

--- a/tests/phpunit/test-cache.php
+++ b/tests/phpunit/test-cache.php
@@ -805,7 +805,10 @@ class CacheTest extends WP_UnitTestCase {
 	 * Remove the object-cache.php from the place we've dropped it
 	 */
 	static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
 		// @codingStandardsIgnoreStart
+		$GLOBALS['wpdb']->query( "TRUNCATE TABLE lcache_events" );
+		$GLOBALS['wpdb']->query( "TRUNCATE TABLE lcache_tags" );
 		unlink( ABSPATH . 'wp-content/object-cache.php' );
 		// @codingStandardsIgnoreEnd
 	}


### PR DESCRIPTION
- Calling `parent::tearDownAfterClass()` ensures `wp_cache_flush()` is executed
- `TRUNCATE TABLE` ensures the LCache tables are emptied

Fixes #12
