### PR TITLE
Adding --no-scripts to composer instructructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Go forth and make awesome! And, once you've built something great, [send us feat
 To install WP LCache, follow these steps:
 
 1. Install the plugin from WordPress.org using the WordPress dashboard.
-1a. Those installing from Github will need to run `composer install --no-dev` after cloning to get the [LCache library](https://github.com/lcache/lcache).
+1a. Those installing from Github will need to run `composer install --no-dev --no-scripts` after cloning to get the [LCache library](https://github.com/lcache/lcache).
 2. Activate the plugin, to ensure LCache's database tables are created. These are created on the plugin activation hook.
 3. Symlink the object cache drop-in to its appropriate location: `cd wp-content; ln -s plugins/wp-lcache/object-cache.php object-cache.php`
 

--- a/readme.txt
+++ b/readme.txt
@@ -28,7 +28,7 @@ Go forth and make awesome! And, once you've built something great, [send us feat
 To install WP LCache, follow these steps:
 
 1. Install the plugin from WordPress.org using the WordPress dashboard.
-1a. Those installing from Github will need to run `composer install --no-dev` after cloning to get the [LCache library](https://github.com/lcache/lcache).
+1a. Those installing from Github will need to run `composer install --no-dev --no-scripts` after cloning to get the [LCache library](https://github.com/lcache/lcache).
 2. Activate the plugin, to ensure LCache's database tables are created. These are created on the plugin activation hook.
 3. Symlink the object cache drop-in to its appropriate location: `cd wp-content; ln -s plugins/wp-lcache/object-cache.php object-cache.php`
 


### PR DESCRIPTION
@joshkoenig, I saw you mention in Slack the errors when running `composer install --no-dev`. Those can be avoided by adding `--no-scripts`.
