### PR TITLE
Emit warnings in CLI when LCache isn't properly configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ If you need to install APCu, the PECL installer is the easiest way to do so.
 * PHP 7.0: `pecl install apcu`
 * PHP 5.6: `pecl install channel://pecl.php.net/apcu-4.0.11`
 
+Enabling APCu for CLI is a matter of adding `apc.enable_cli='on'` to your `etc/php5/cli/php.ini`.
+
 If you can't easily use PHP 5.6 or greater, you should switch to a more responsible hosting provider.
 
 ### Admin Notices ###

--- a/object-cache.php
+++ b/object-cache.php
@@ -993,7 +993,13 @@ class WP_Object_Cache {
 	 * Get the missing requirements error message
 	 */
 	private function get_missing_requirements_error_message() {
-		return sprintf( 'Warning! Missing %s, which %s required by WP LCache object cache. <a href="https://wordpress.org/plugins/wp-lcache/installation/" target="_blank">See "Installation" for more details</a>.', implode( ', ', $this->missing_requirements ), count( $this->missing_requirements ) > 1 ? 'are' : 'is' );
+		$message = sprintf( 'Warning! Missing %s, which %s required by WP LCache object cache. ', implode( ', ', $this->missing_requirements ), count( $this->missing_requirements ) > 1 ? 'are' : 'is' );
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			$message .= 'See "Installation" for more details: https://wordpress.org/plugins/wp-lcache/installation/';
+		} else {
+			$message .= '<a href="https://wordpress.org/plugins/wp-lcache/installation/" target="_blank">See "Installation" for more details</a>.';
+		}
+		return $message;
 	}
 
 	/**

--- a/object-cache.php
+++ b/object-cache.php
@@ -986,8 +986,14 @@ class WP_Object_Cache {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
-		$message = wp_sprintf( 'Warning! Missing %l, which %s required by WP LCache object cache. <a href="https://wordpress.org/plugins/wp-lcache/installation/" target="_blank">See "Installation" for more details</a>.', $this->missing_requirements, count( $this->missing_requirements ) > 1 ? 'are' : 'is' );
-		echo '<div class="message error"><p>' . wp_kses_post( $message ) . '</p></div>';
+		echo '<div class="message error"><p>' . wp_kses_post( $this->get_missing_requirements_error_message() ) . '</p></div>';
+	}
+
+	/**
+	 * Get the missing requirements error message
+	 */
+	private function get_missing_requirements_error_message() {
+		return sprintf( 'Warning! Missing %s, which %s required by WP LCache object cache. <a href="https://wordpress.org/plugins/wp-lcache/installation/" target="_blank">See "Installation" for more details</a>.', implode( ', ', $this->missing_requirements ), count( $this->missing_requirements ) > 1 ? 'are' : 'is' );
 	}
 
 	/**
@@ -1066,8 +1072,12 @@ class WP_Object_Cache {
 			}
 		}
 
-		if ( ! empty( $this->missing_requirements ) && function_exists( 'add_action' ) ) {
-			add_action( 'admin_notices', array( $this, 'wp_action_admin_notices_warn_missing_lcache' ) );
+		if ( ! empty( $this->missing_requirements ) ) {
+			if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
+				WP_CLI::warning( $this->get_missing_requirements_error_message() );
+			} else if ( function_exists( 'add_action' ) ) {
+				add_action( 'admin_notices', array( $this, 'wp_action_admin_notices_warn_missing_lcache' ) );
+			}
 		}
 
 		$this->global_prefix = ( $this->multisite || defined( 'CUSTOM_USER_TABLE' ) && defined( 'CUSTOM_USER_META_TABLE' ) ) ? '' : $table_prefix;

--- a/readme.txt
+++ b/readme.txt
@@ -53,6 +53,8 @@ If you need to install APCu, the PECL installer is the easiest way to do so.
 * PHP 7.0: `pecl install apcu`
 * PHP 5.6: `pecl install channel://pecl.php.net/apcu-4.0.11`
 
+Enabling APCu for CLI is a matter of adding `apc.enable_cli='on'` to your `etc/php5/cli/php.ini`.
+
 If you can't easily use PHP 5.6 or greater, you should switch to a more responsible hosting provider.
 
 = Admin Notices =


### PR DESCRIPTION
```
salty-wordpress ➜  wp-lcache  wp cache flush
Warning: Warning! Missing APCu extension enabled, which is required by WP LCache object cache. See "Installation" for more details: https://wordpress.org/plugins/wp-lcache/installation/
Success: The cache was flushed.
```
