### PR TITLE
Split alloptions into separate cache keys

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -468,6 +468,10 @@ class WP_Object_Cache {
 			$group = 'default';
 		}
 
+		if ( 'alloptions' === $key && 'options' === $group ) {
+			return $this->delete_alloptions( $force );
+		}
+
 		if ( ! $force && ! $this->exists( $key, $group ) ) {
 			return false;
 		}
@@ -769,6 +773,23 @@ class WP_Object_Cache {
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Delete combined alloptions from separate cache keys and values.
+	 *
+	 * @param bool $force Optional. Whether to force the unsetting of the cache
+	 *		key in the group
+	 * @return boolean
+	 */
+	protected function delete_alloptions( $force = false ) {
+		$keys = $this->get( 'keys', 'lcache_alloptions_keys', $force );
+		if ( ! empty( $keys ) && is_array( $keys ) ) {
+			foreach ( array_keys( $keys ) as $key ) {
+				$this->delete( $key, 'lcache_alloptions_values', $force );
+			}
+		}
+		return $this->delete( 'keys', 'lcache_alloptions_keys' );
 	}
 
 	/**

--- a/object-cache.php
+++ b/object-cache.php
@@ -544,6 +544,10 @@ class WP_Object_Cache {
 			$group = 'default';
 		}
 
+		if ( 'alloptions' === $key && 'options' === $group ) {
+			return $this->get_alloptions( $force, $found );
+		}
+
 		// Key is set internally, so we can use this value
 		if ( $this->isset_internal( $key, $group ) && ! $force ) {
 			$this->cache_hits += 1;
@@ -679,6 +683,10 @@ class WP_Object_Cache {
 			$group = 'default';
 		}
 
+		if ( 'alloptions' === $key && 'options' === $group ) {
+			return $this->set_alloptions( $data, $expire );
+		}
+
 		if ( is_object( $data ) ) {
 			$data = clone $data;
 		}
@@ -697,6 +705,70 @@ class WP_Object_Cache {
 		$expire = 0 === $expire ? null : $expire;
 		$this->call_lcache( 'set', array( $key, $group ), $data, $expire );
 		return true;
+	}
+
+	/**
+	 * Get combined alloptions from separate cache keys and values.
+	 *
+	 * @param string $force Whether to force a refetch rather than relying on the local cache (default is false)
+	 * @param bool $found Optional. Whether the key was found in the cache. Disambiguates a return of false, a storable value. Passed by reference. Default null.
+	 * @return array
+	 */
+	protected function get_alloptions( $force = false, &$found = null ) {
+		$keys = $this->get( 'keys', 'lcache_alloptions_keys', $force );
+		$value = array();
+		if ( empty( $keys ) || ! is_array( $keys ) ) {
+			$found = false;
+			return $value;
+		}
+		foreach ( array_keys( $keys ) as $key ) {
+			$value[ $key ] = $this->get( $key, 'lcache_alloptions_values', $force );
+		}
+		$found = true;
+		return $value;
+	}
+
+	/**
+	 * Set alloptions as separate cache keys and values.
+	 *
+	 * @param array $data Original alloptions data.
+	 * @param integer $expire Expiration TTL.
+	 * @return bool
+	 */
+	protected function set_alloptions( $data, $expire = 0 ) {
+		$existing = $this->get_alloptions();
+		$keys = $this->get( 'keys', 'lcache_alloptions_keys' );
+		if ( empty( $keys ) || ! is_array( $keys ) ) {
+			$keys = array();
+		}
+		// Set any new values
+		foreach ( $data as $key => $value ) {
+			if ( isset( $existing[ $key ] ) && $existing[ $key ] === $value ) {
+				continue;
+			}
+			if ( ! isset( $keys[ $key ] ) ) {
+				$keys[ $key ] = true;
+			}
+			if ( ! $this->set( $key, $value, 'lcache_alloptions_values', $expire ) ) {
+				return false;
+			}
+		}
+		// Delete any removed values
+		foreach ( $existing as $key => $value ) {
+			if ( isset( $data[ $key ] ) ) {
+				continue;
+			}
+			if ( isset( $keys[ $key ] ) ) {
+				unset( $keys[ $key ] );
+			}
+			if ( ! $this->delete( $key, 'lcache_alloptions_values' ) ) {
+				return false;
+			}
+		}
+		if ( $this->set( 'keys', $keys, 'lcache_alloptions_keys', $expire ) ) {
+			return true;
+		}
+		return false;
 	}
 
 	/**

--- a/tests/phpunit/test-cache.php
+++ b/tests/phpunit/test-cache.php
@@ -997,6 +997,11 @@ class CacheTest extends WP_UnitTestCase {
 		$this->assertEquals( 1, $wp_object_cache->cache_hits );
 		$this->assertEquals( 1, $wp_object_cache->cache_misses );
 
+		// Ensure deleting alloptions works as expected
+		wp_cache_delete( 'alloptions', 'options' );
+		$this->assertEmpty( wp_cache_get( 'lcache_object', 'lcache_alloptions_values' ) );
+		$this->assertEmpty( wp_cache_get( 'keys', 'lcache_alloptions_keys' ) );
+
 	}
 
 	public function tearDown() {

--- a/tests/phpunit/test-cache.php
+++ b/tests/phpunit/test-cache.php
@@ -951,24 +951,52 @@ class CacheTest extends WP_UnitTestCase {
 		// Prime alloptions cache for first cache
 		$wp_object_cache = $first_cache;
 		get_option( 'lcache_object' );
+		$this->assertEquals( 'bar', $first_cache->get( 'lcache_object', 'lcache_alloptions_values' ) );
+		$this->assertEquals( 'banana', $first_cache->get( 'lcache_fruit','lcache_alloptions_values' ) );
 		// Prime alloptions cache for second cache
 		$wp_object_cache = $second_cache;
 		get_option( 'lcache_object' );
+		$this->assertEquals( 'bar', $second_cache->get( 'lcache_object', 'lcache_alloptions_values' ) );
+		$this->assertEquals( 'banana', $second_cache->get( 'lcache_fruit', 'lcache_alloptions_values' ) );
 
 		// Write a new value to the first option with the first cache
 		$wp_object_cache = $first_cache;
 		update_option( 'lcache_object', 'stick' );
+		$wp_object_cache->cache_hits = $wp_object_cache->cache_misses = 0;
+		$this->assertEquals( 'stick', $first_cache->get( 'lcache_object', 'lcache_alloptions_values' ) );
+		$this->assertEquals( 'banana', $first_cache->get( 'lcache_fruit', 'lcache_alloptions_values' ) );
+		$this->assertEquals( 2, $wp_object_cache->cache_hits );
+		$this->assertEquals( 0, $wp_object_cache->cache_misses );
 
 		// Write a new value to the second option with the second cache
 		// Updating this second option shouldn't overwrite cache value for the first
 		$wp_object_cache = $second_cache;
 		update_option( 'lcache_fruit', 'orange' );
+		$wp_object_cache->cache_hits = $wp_object_cache->cache_misses = 0;
+		$this->assertEquals( 'orange', $second_cache->get( 'lcache_fruit', 'lcache_alloptions_values' ) );
+		$this->assertEquals( 'bar', $second_cache->get( 'lcache_object', 'lcache_alloptions_values' ) );
+		$this->assertEquals( 2, $wp_object_cache->cache_hits );
+		$this->assertEquals( 0, $wp_object_cache->cache_misses );
 
 		// Ensure a new request has the correct values for both written options
 		$third_cache =& $this->init_cache();
 		$wp_object_cache = $third_cache;
 		$this->assertEquals( 'orange', get_option( 'lcache_fruit' ) );
 		$this->assertEquals( 'stick', get_option( 'lcache_object' ) );
+		$wp_object_cache->cache_hits = $wp_object_cache->cache_misses = 0;
+		$this->assertEquals( 'stick', $third_cache->get( 'lcache_object', 'lcache_alloptions_values' ) );
+		$this->assertEquals( 'orange', $third_cache->get( 'lcache_fruit', 'lcache_alloptions_values' ) );
+		$this->assertEquals( 2, $wp_object_cache->cache_hits );
+		$this->assertEquals( 0, $wp_object_cache->cache_misses );
+
+		// Ensure deleting an option works as expected
+		delete_option( 'lcache_fruit' );
+		$wp_object_cache->cache_hits = $wp_object_cache->cache_misses = 0;
+		$this->assertEmpty( $third_cache->get( 'lcache_fruit', 'lcache_alloptions_values' ) );
+		$this->assertEquals( 'stick', $third_cache->get( 'lcache_object', 'lcache_alloptions_values' ) );
+		$this->assertEquals( 1, $wp_object_cache->cache_hits );
+		$this->assertEquals( 1, $wp_object_cache->cache_misses );
+
 	}
 
 	public function tearDown() {


### PR DESCRIPTION
Doing so helps to mitigate the classic race condition described in https://core.trac.wordpress.org/ticket/31245

Inspiration from https://github.com/humanmade/memcache-object-cache/blob/master/object-cache.php#L153-L231 and https://github.com/humanmade/wordpress-pecl-memcached-object-cache/pull/1/files
