### PR TITLE
Only load LCache library for PHP 5.6+

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -12,7 +12,7 @@ use \LCache\NullL1;
 if ( ! defined( 'WP_LCACHE_AUTOLOADER' ) ) {
 	define( 'WP_LCACHE_AUTOLOADER', dirname( realpath( __FILE__ ) ) . '/vendor/autoload.php' );
 }
-if ( file_exists( WP_LCACHE_AUTOLOADER ) ) {
+if ( file_exists( WP_LCACHE_AUTOLOADER ) && version_compare( PHP_VERSION, '5.6' ) >= 0 ) {
 	require_once( WP_LCACHE_AUTOLOADER );
 }
 


### PR DESCRIPTION
This ensures it doesn't fatal on older versions of PHP