### PR TITLE
Update `bin/install-wp-tests.sh` to latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,11 @@ branches:
 
 matrix:
   include:
-    - php: 5.6
+    - php: 7.1
       env: WP_VERSION=latest PHP_APCU=enabled
     - php: 7.0
+      env: WP_VERSION=latest PHP_APCU=enabled
+    - php: 5.6
       env: WP_VERSION=latest PHP_APCU=enabled
     - php: 5.6
       env: WP_VERSION=latest PHP_APCU=disabled
@@ -29,7 +31,7 @@ before_script:
       if [[ ! -z "$WP_VERSION" ]] ; then
         bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
         if [[ "$PHP_APCU" == "enabled" ]] ; then
-          if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
+          if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
             echo "no" | pecl install apcu
           else
             echo "no\nno" | pecl install channel://pecl.php.net/apcu-4.0.11
@@ -38,7 +40,7 @@ before_script:
         fi
       fi
     - |
-      if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
+      if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
         composer global require "phpunit/phpunit=5.6.*"
       else
         composer global require "phpunit/phpunit=4.8.*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,14 @@ matrix:
       env: WP_VERSION=latest PHP_APCU=enabled
     - php: 7.0.15
       env: WP_VERSION=latest PHP_APCU=enabled
+    - php: 5.6
+      env: WP_VERSION=latest PHP_APCU=enabled
+    - php: 5.6
+      env: WP_VERSION=latest PHP_APCU=disabled
+    - php: 5.6
+      env: WP_VERSION=nightly PHP_APCU=enabled
+    - php: 5.6
+      env: WP_TRAVISCI=phpcs
 
 before_script:
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,6 @@ matrix:
       env: WP_VERSION=latest PHP_APCU=enabled
     - php: 7.0
       env: WP_VERSION=latest PHP_APCU=enabled
-    - php: 5.6
-      env: WP_VERSION=latest PHP_APCU=enabled
-    - php: 5.6
-      env: WP_VERSION=latest PHP_APCU=disabled
-    - php: 5.6
-      env: WP_VERSION=nightly PHP_APCU=enabled
-    - php: 5.6
-      env: WP_TRAVISCI=phpcs
 
 before_script:
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ branches:
 
 matrix:
   include:
-    - php: 7.1
+    - php: 7.1.0
       env: WP_VERSION=latest PHP_APCU=enabled
     - php: 7.0.15
       env: WP_VERSION=latest PHP_APCU=enabled

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
   include:
     - php: 7.1
       env: WP_VERSION=latest PHP_APCU=enabled
-    - php: 7.0
+    - php: 7.0.15
       env: WP_VERSION=latest PHP_APCU=enabled
 
 before_script:

--- a/object-cache.php
+++ b/object-cache.php
@@ -12,8 +12,8 @@ use \LCache\NullL1;
 if ( ! defined( 'WP_LCACHE_AUTOLOADER' ) ) {
 	define( 'WP_LCACHE_AUTOLOADER', dirname( realpath( __FILE__ ) ) . '/vendor/autoload.php' );
 }
-if ( version_compare( PHP_VERSION, '5.6' ) >= 0 ) {
-	include_once( WP_LCACHE_AUTOLOADER );
+if ( file_exists( WP_LCACHE_AUTOLOADER ) && version_compare( PHP_VERSION, '5.6' ) >= 0 ) {
+	require_once( WP_LCACHE_AUTOLOADER );
 }
 
 # Users with setups where multiple installs share a common wp-config.php or $table_prefix

--- a/object-cache.php
+++ b/object-cache.php
@@ -12,8 +12,8 @@ use \LCache\NullL1;
 if ( ! defined( 'WP_LCACHE_AUTOLOADER' ) ) {
 	define( 'WP_LCACHE_AUTOLOADER', dirname( realpath( __FILE__ ) ) . '/vendor/autoload.php' );
 }
-if ( file_exists( WP_LCACHE_AUTOLOADER ) && version_compare( PHP_VERSION, '5.6' ) >= 0 ) {
-	require_once( WP_LCACHE_AUTOLOADER );
+if ( version_compare( PHP_VERSION, '5.6' ) >= 0 ) {
+	include_once( WP_LCACHE_AUTOLOADER );
 }
 
 # Users with setups where multiple installs share a common wp-config.php or $table_prefix

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -22,9 +22,6 @@ require dirname( dirname( dirname( __FILE__ ) ) ) . '/wp-lcache.php';
 
 // Easiest way to get this to where WordPress will load it
 define( 'WP_LCACHE_AUTOLOADER', dirname( dirname( __DIR__ ) ) . '/vendor/autoload.php' );
-error_log( WP_LCACHE_AUTOLOADER );
-error_log( file_exists( WP_LCACHE_AUTOLOADER ) );
-error_log( var_export( glob( dirname( WP_LCACHE_AUTOLOADER ) . '/*' ), true ) );
 copy( dirname( dirname( dirname( __FILE__ ) ) ) . '/object-cache.php', $_core_dir . '/wp-content/object-cache.php' );
 
 require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -22,6 +22,9 @@ require dirname( dirname( dirname( __FILE__ ) ) ) . '/wp-lcache.php';
 
 // Easiest way to get this to where WordPress will load it
 define( 'WP_LCACHE_AUTOLOADER', dirname( dirname( __DIR__ ) ) . '/vendor/autoload.php' );
+error_log( WP_LCACHE_AUTOLOADER );
+error_log( file_exists( WP_LCACHE_AUTOLOADER ) );
+error_log( var_export( glob( dirname( WP_LCACHE_AUTOLOADER ) . '/*' ), true ) );
 copy( dirname( dirname( dirname( __FILE__ ) ) ) . '/object-cache.php', $_core_dir . '/wp-content/object-cache.php' );
 
 require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -21,7 +21,7 @@ $_SERVER['SERVER_PORT'] = 80;
 require dirname( dirname( dirname( __FILE__ ) ) ) . '/wp-lcache.php';
 
 // Easiest way to get this to where WordPress will load it
-define( 'WP_LCACHE_AUTOLOADER', dirname( dirname( dirname( __FILE__ ) ) ) . '/vendor/autoload.php' );
+define( 'WP_LCACHE_AUTOLOADER', dirname( dirname( __DIR__ ) ) . '/vendor/autoload.php' );
 copy( dirname( dirname( dirname( __FILE__ ) ) ) . '/object-cache.php', $_core_dir . '/wp-content/object-cache.php' );
 
 require $_tests_dir . '/includes/bootstrap.php';


### PR DESCRIPTION
This prevents an error notice from core's test suite