### PR TITLE
Normalize address key to comply with DB column length

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -1041,8 +1041,8 @@ class WP_Object_Cache {
 		$is_ascii = mb_check_encoding( $key, 'ASCII' );
 
 		// 251 represents the max length of the address column (VARCHAR 255),
-		// minus the group length, minus a buffer of 4 chars that will be added
-		// to the column in `Address::serialize()` - xx:{group}:{key}
+		// minus a buffer of 4 chars that are added by `Address::serialize()`
+		// xx:{group}:{key}
 		$key_max_length = 251 - strlen( $group );
 
 		if ( $is_ascii && strlen( $key ) <= $key_max_length ) {

--- a/tests/phpunit/test-cache.php
+++ b/tests/phpunit/test-cache.php
@@ -73,6 +73,7 @@ class CacheTest extends WP_UnitTestCase {
 		$non_ascii_long_address = new \LCache\Address( $group, $non_ascii_long_key );
 		$this->assertRegexp( '/^24:lcache_alloptions_values:/', $non_ascii_long_address->serialize() );
 		$this->assertRegexp( '/' . hash( 'sha256', $non_ascii_long ) . '$/', $non_ascii_long_address->serialize() );
+		$this->assertEquals( 92, strlen( $non_ascii_long_address->serialize() ) ); // 4 + 24 + 64 = 92
 
 		// Non-ASCII short
 		$non_ascii_short = '愛€£¢¡';
@@ -80,6 +81,7 @@ class CacheTest extends WP_UnitTestCase {
 		$non_ascii_short_address = new \LCache\Address( $group, $non_ascii_short_key );
 		$this->assertRegexp( '/^24:lcache_alloptions_values:/', $non_ascii_short_address->serialize() );
 		$this->assertRegexp( '/' . hash( 'sha256', $non_ascii_short ) . '$/', $non_ascii_short_address->serialize() );
+		$this->assertEquals( 92, strlen( $non_ascii_short_address->serialize() ) ); // 4 + 24 + 64 = 92
 
 		// ASCII long
 		$ascii_long = str_repeat( 'abcde', 100 );
@@ -87,6 +89,7 @@ class CacheTest extends WP_UnitTestCase {
 		$ascii_long_address = new \LCache\Address( $group, $ascii_long_key );
 		$this->assertRegexp( '/^24:lcache_alloptions_values:/', $ascii_long_address->serialize() );
 		$this->assertRegexp( '/' . hash( 'sha256', $ascii_long ) . '$/', $ascii_long_address->serialize() );
+		$this->assertEquals( 255, strlen( $ascii_long_address->serialize() ) );
 
 		// ASCII short
 		$ascii_short = 'abcde';
@@ -99,6 +102,7 @@ class CacheTest extends WP_UnitTestCase {
 		$ascii_max_key = WP_Object_Cache::normalize_address_key( $group, $ascii_max );
 		$ascii_max_address = new \LCache\Address( $group, $ascii_max_key );
 		$this->assertRegexp( '/^24:lcache_alloptions_values:' . $ascii_max . '$/', $ascii_max_address->serialize() );
+		$this->assertEquals( 255, strlen( $ascii_max_address->serialize() ) );
 
 		// ASCII one over the max
 		$ascii_over_max = str_repeat( 'a', 228 );
@@ -106,6 +110,7 @@ class CacheTest extends WP_UnitTestCase {
 		$ascii_over_max_address = new \LCache\Address( $group, $ascii_over_max_key );
 		$this->assertRegexp( '/^24:lcache_alloptions_values:/', $ascii_over_max_address->serialize() );
 		$this->assertRegexp( '/' . hash( 'sha256', $ascii_over_max ) . '$/', $ascii_over_max_address->serialize() );
+		$this->assertEquals( 255, strlen( $ascii_over_max_address->serialize() ) );
 	}
 
 	public function test_loaded() {


### PR DESCRIPTION
Fixes #114 

Although the unit tests pass, I was unable to reproduce the exact issue [described by the OP](https://wordpress.org/support/topic/error-with-formidable-forms/).

@rdanamcd Perhaps there is a Pro version of Formidable with more features that I'm not seeing in the free version? Would be great if you could confirm this PR, or provide more exact steps I can use to reproduce. Thanks!