### PR TITLE
Always run table init on the `enable` CLI command

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -4,6 +4,7 @@ class WP_LCache_CLI {
 
 	/**
 	 * Enable WP LCache by creating a stub for object-cache.php
+	 * and/or creating the required database tables.
 	 */
 	public function enable() {
 		wp_lcache_initialize_database_schema();

--- a/cli.php
+++ b/cli.php
@@ -6,6 +6,7 @@ class WP_LCache_CLI {
 	 * Enable WP LCache by creating a stub for object-cache.php
 	 */
 	public function enable() {
+		wp_lcache_initialize_database_schema();
 		if ( defined( 'WP_LCACHE_OBJECT_CACHE' ) && WP_LCACHE_OBJECT_CACHE ) {
 			WP_CLI::success( 'WP LCache is already enabled.' );
 			return;


### PR DESCRIPTION
If you try to use WP LCache as a must-use plugin no activation hook is fired, so the required tables are never created.

Since the `wp lcache enable` command creates a stub for `object-cache.php` it may as well create the required database tables if they are missing too.