### PR TITLE
Remove tags table and introduce database migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,6 @@ PHPUnit requires the [WordPress PHPUnit test suite](https://make.wordpress.org/c
 
 Behat requires a Pantheon site. Once you've created the site, you'll need [install Terminus](https://github.com/pantheon-systems/terminus#installation), and set the `TERMINUS_TOKEN`, `TERMINUS_SITE`, and `TERMINUS_ENV` environment variables. Then, you can run `./bin/behat-prepare.sh` to prepare the site for the test suite.
 
-## Upgrade Notice ##
-
-### 0.2.2 ###
-Existing WP LCache users will need to alter the `value` column on the lcache_event table from `BLOB` to `LONGBLOB`.
-
 ## Changelog ##
 
 ### 0.5.1 (April 25th, 2017) ###

--- a/cli.php
+++ b/cli.php
@@ -8,6 +8,7 @@ class WP_LCache_CLI {
 	 */
 	public function enable() {
 		wp_lcache_initialize_database_schema();
+		wp_lcache_run_database_migrations();
 		if ( defined( 'WP_LCACHE_OBJECT_CACHE' ) && WP_LCACHE_OBJECT_CACHE ) {
 			WP_CLI::success( 'WP LCache is already enabled.' );
 			return;

--- a/readme.txt
+++ b/readme.txt
@@ -105,11 +105,6 @@ PHPUnit requires the [WordPress PHPUnit test suite](https://make.wordpress.org/c
 
 Behat requires a Pantheon site. Once you've created the site, you'll need [install Terminus](https://github.com/pantheon-systems/terminus#installation), and set the `TERMINUS_TOKEN`, `TERMINUS_SITE`, and `TERMINUS_ENV` environment variables. Then, you can run `./bin/behat-prepare.sh` to prepare the site for the test suite.
 
-== Upgrade Notice ==
-
-= 0.2.2 =
-Existing WP LCache users will need to alter the `value` column on the lcache_event table from `BLOB` to `LONGBLOB`.
-
 == Changelog ==
 
 = 0.5.1 (April 25th, 2017) =

--- a/wp-lcache.php
+++ b/wp-lcache.php
@@ -73,10 +73,10 @@ if ( function_exists( 'add_action' ) ) {
  * Run required database migrations (in ascending order) upon version change
  */
 function wp_lcache_run_database_migrations() {
-	wp_cache_delete( 'wp_lcache_version', 'options' );
+	wp_cache_delete( 'wp_lcache_db_version', 'options' );
 
 	$plugin      = get_plugin_data( __FILE__, false, false );
-	$old_version = get_option( 'wp_lcache_version', '0.5.1' ); // Last version before migrations were introduced
+	$old_version = get_option( 'wp_lcache_db_version', '0.5.1' ); // Last version before migrations were introduced
 	$new_version = ! empty( $plugin['Version'] ) ? $plugin['Version'] : false;
 
 	if ( ! $new_version || $old_version === $new_version ) {
@@ -93,7 +93,7 @@ function wp_lcache_run_database_migrations() {
 		}
 	}
 
-	update_option( 'wp_lcache_version', $new_version, false );
+	update_option( 'wp_lcache_db_version', $new_version, false );
 }
 
 /**

--- a/wp-lcache.php
+++ b/wp-lcache.php
@@ -104,11 +104,15 @@ function wp_lcache_database_migration_0_6_0() {
 
 	// First introduced in v0.2.2 but a migration was never provided
 	$events_table = $GLOBALS['table_prefix'] . 'lcache_events';
+	// @codingStandardsIgnoreStart
 	$wpdb->query( "ALTER TABLE `{$events_table}` MODIFY COLUMN `value` LONGBLOB;" );
+	// @codingStandardsIgnoreEND
 
 	// Remove a currently unused `tags` table
 	$tags_table = $GLOBALS['table_prefix'] . 'lcache_tags';
+	// @codingStandardsIgnoreStart
 	$wpdb->query( "DROP TABLE IF EXISTS `{$tags_table}`;" );
+	// @codingStandardsIgnoreEnd
 }
 
 /**

--- a/wp-lcache.php
+++ b/wp-lcache.php
@@ -100,6 +100,11 @@ function wp_lcache_run_database_migrations() {
 function wp_lcache_database_migration_0_6_0() {
 	global $wpdb;
 
+	// First introduced in v0.2.2 but a migration was never provided
+	$events_table = $GLOBALS['table_prefix'] . 'lcache_events';
+	$wpdb->query( "ALTER TABLE `{$events_table}` MODIFY COLUMN `value` LONGBLOB;" );
+
+	// Remove a currently unused `tags` table
 	$tags_table = $GLOBALS['table_prefix'] . 'lcache_tags';
 	$wpdb->query( "DROP TABLE IF EXISTS `{$tags_table}`;" );
 }

--- a/wp-lcache.php
+++ b/wp-lcache.php
@@ -73,6 +73,8 @@ if ( function_exists( 'add_action' ) ) {
  * Run required database migrations (in ascending order) upon version change
  */
 function wp_lcache_run_database_migrations() {
+	wp_cache_delete( 'wp_lcache_version', 'options' );
+
 	$plugin      = get_plugin_data( __FILE__, false, false );
 	$old_version = get_option( 'wp_lcache_version', '0.5.1' ); // Last version before migrations were introduced
 	$new_version = ! empty( $plugin['Version'] ) ? $plugin['Version'] : false;

--- a/wp-lcache.php
+++ b/wp-lcache.php
@@ -93,7 +93,7 @@ function wp_lcache_run_database_migrations() {
 		}
 	}
 
-	update_option( 'wp_lcache_version', $new_version );
+	update_option( 'wp_lcache_version', $new_version, false );
 }
 
 /**

--- a/wp-lcache.php
+++ b/wp-lcache.php
@@ -47,12 +47,11 @@ function wp_lcache_initialize_database_schema() {
 		KEY `lookup_miss` (`address`,`event_id`)
 		) ENGINE=InnoDB DEFAULT CHARSET=utf8;" );
 	// @codingStandardsIgnoreEnd
-
-	wp_lcache_run_database_migrations();
 }
 
 if ( function_exists( 'register_activation_hook' ) ) {
 	register_activation_hook( __FILE__, 'wp_lcache_initialize_database_schema' );
+	register_activation_hook( __FILE__, 'wp_lcache_run_database_migrations' );
 }
 
 /**
@@ -66,10 +65,12 @@ function wp_lcache_upgrader_process_complete( $upgrader, $hook_extra ) {
 		wp_lcache_run_database_migrations();
 	}
 }
-add_action( 'upgrader_process_complete', 'wp_lcache_upgrader_process_complete', 10, 2 );
+if ( function_exists( 'add_action' ) ) {
+	add_action( 'upgrader_process_complete', 'wp_lcache_upgrader_process_complete', 10, 2 );
+}
 
 /**
- * Run any required database migrations on version change
+ * Run required database migrations (in ascending order) upon version change
  */
 function wp_lcache_run_database_migrations() {
 	$plugin      = get_plugin_data( __FILE__, false, false );

--- a/wp-lcache.php
+++ b/wp-lcache.php
@@ -88,7 +88,7 @@ function wp_lcache_run_database_migrations() {
 	);
 
 	foreach ( $migrations as $version => $callback ) {
-		if ( $old_version < $version && function_exists( $callback ) ) {
+		if ( version_compare( $old_version, $version, '<' ) && function_exists( $callback ) ) {
 			$callback();
 		}
 	}


### PR DESCRIPTION
Fixes #123

- Remove a currently unused `tags` table
- Migration for schema change introduced in v0.2.2
- Pattern to follow for future database migrations

Note: This PR does assume it would land in the `0.6.0` milestone.