### PR TITLE
Only require APCu to be enabled for web requests

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -1119,7 +1119,7 @@ class WP_Object_Cache {
 		// @codingStandardsIgnoreStart
 		if ( ! function_exists( 'apcu_sma_info' ) ) {
 			$missing['apcu-installed'] = 'APCu extension installed';
-		} elseif ( function_exists( 'apcu_sma_info' ) && ! @apcu_sma_info() ) {
+		} elseif ( php_sapi_name() !== 'cli' && function_exists( 'apcu_sma_info' ) && ! @apcu_sma_info() ) {
 			$missing['apcu-enabled'] = 'APCu extension enabled';
 		}
 		// @codingStandardsIgnoreEnd

--- a/object-cache.php
+++ b/object-cache.php
@@ -1115,14 +1115,17 @@ class WP_Object_Cache {
 		if ( ! class_exists( '\LCache\NullL1' ) ) {
 			$missing['lcache'] = 'LCache library';
 		}
-		// apcu_sma_info() triggers a warning when APCu is disabled
-		// @codingStandardsIgnoreStart
-		if ( ! function_exists( 'apcu_sma_info' ) ) {
-			$missing['apcu-installed'] = 'APCu extension installed';
-		} elseif ( php_sapi_name() !== 'cli' && function_exists( 'apcu_sma_info' ) && ! @apcu_sma_info() ) {
-			$missing['apcu-enabled'] = 'APCu extension enabled';
+
+		if ( 'cli' !== php_sapi_name() ) {
+			// apcu_sma_info() triggers a warning when APCu is disabled
+			// @codingStandardsIgnoreStart
+			if ( ! function_exists( 'apcu_sma_info' ) ) {
+				$missing['apcu-installed'] = 'APCu extension installed';
+			} elseif ( function_exists( 'apcu_sma_info' ) && ! @apcu_sma_info() ) {
+				$missing['apcu-enabled'] = 'APCu extension enabled';
+			}
+			// @codingStandardsIgnoreEnd
 		}
-		// @codingStandardsIgnoreEnd
 		if ( -1 === version_compare( PHP_VERSION, '5.6' ) ) {
 			$missing['php'] = 'PHP 5.6 or greater';
 		}


### PR DESCRIPTION
In CLI, WP LCache will fall back to NullL1, which is functionally
equivalent to APCuL1

Fixes #126