### PR TITLE
Support utf8mb4

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -1068,6 +1068,8 @@ class WP_Object_Cache {
 	 * @return string
 	 */
 	public static function get_pdo_dsn( $host, $name, $charset ) {
+		$charset = ( 'utf8' === $charset ) ? 'utf8mb4' : $charset;
+
 		if ( '.sock' === substr( $host, -5 ) ) {
 			return sprintf( 'mysql:unix_socket=%s;dbname=%s;charset=%s', $host, $name, $charset );
 		}

--- a/tests/phpunit/test-cache.php
+++ b/tests/phpunit/test-cache.php
@@ -45,23 +45,27 @@ class CacheTest extends WP_UnitTestCase {
 	}
 
 	public function test_pdo_dsn() {
-		$this->assertEquals( 'mysql:host=localhost;dbname=wordpress_test;charset=utf8', WP_Object_Cache::get_pdo_dsn( 'localhost', 'wordpress_test', 'utf8' ) );
-		$this->assertEquals( 'mysql:host=127.0.0.1;dbname=wordpress_test;charset=utf8', WP_Object_Cache::get_pdo_dsn( '127.0.0.1', 'wordpress_test', 'utf8' ) );
-		$this->assertEquals( 'mysql:host=db.www.example.com;dbname=wordpress_test;charset=utf8', WP_Object_Cache::get_pdo_dsn( 'db.www.example.com', 'wordpress_test', 'utf8' ) );
+		$this->assertEquals( 'mysql:host=localhost;dbname=wordpress_test;charset=utf8mb4', WP_Object_Cache::get_pdo_dsn( 'localhost', 'wordpress_test', 'utf8' ) );
+		$this->assertEquals( 'mysql:host=127.0.0.1;dbname=wordpress_test;charset=utf8mb4', WP_Object_Cache::get_pdo_dsn( '127.0.0.1', 'wordpress_test', 'utf8' ) );
+		$this->assertEquals( 'mysql:host=db.www.example.com;dbname=wordpress_test;charset=utf8mb4', WP_Object_Cache::get_pdo_dsn( 'db.www.example.com', 'wordpress_test', 'utf8' ) );
 		// Invalid port numbers
-		$this->assertEquals( 'mysql:host=localhost;dbname=wordpress_test;charset=utf8', WP_Object_Cache::get_pdo_dsn( 'localhost:foo', 'wordpress_test', 'utf8' ) );
-		$this->assertEquals( 'mysql:host=localhost;dbname=wordpress_test;charset=utf8', WP_Object_Cache::get_pdo_dsn( 'localhost:0', 'wordpress_test', 'utf8' ) );
-		$this->assertEquals( 'mysql:host=localhost;dbname=wordpress_test;charset=utf8', WP_Object_Cache::get_pdo_dsn( 'localhost:77777', 'wordpress_test', 'utf8' ) );
+		$this->assertEquals( 'mysql:host=localhost;dbname=wordpress_test;charset=utf8mb4', WP_Object_Cache::get_pdo_dsn( 'localhost:foo', 'wordpress_test', 'utf8' ) );
+		$this->assertEquals( 'mysql:host=localhost;dbname=wordpress_test;charset=utf8mb4', WP_Object_Cache::get_pdo_dsn( 'localhost:0', 'wordpress_test', 'utf8' ) );
+		$this->assertEquals( 'mysql:host=localhost;dbname=wordpress_test;charset=utf8mb4', WP_Object_Cache::get_pdo_dsn( 'localhost:77777', 'wordpress_test', 'utf8' ) );
+		// Non-UTF-8 charsets
+		$this->assertEquals( 'mysql:host=localhost;dbname=wordpress_test;charset=latin1', WP_Object_Cache::get_pdo_dsn( 'localhost', 'wordpress_test', 'latin1' ) );
+		$this->assertEquals( 'mysql:host=localhost;dbname=wordpress_test;charset=utf16', WP_Object_Cache::get_pdo_dsn( 'localhost', 'wordpress_test', 'utf16' ) );
+		$this->assertEquals( 'mysql:host=localhost;dbname=wordpress_test;charset=utf32', WP_Object_Cache::get_pdo_dsn( 'localhost', 'wordpress_test', 'utf32' ) );
 	}
 
 	public function test_pdo_dsn_with_port() {
-		$this->assertEquals( 'mysql:host=localhost;port=3306;dbname=wordpress_test;charset=utf8', WP_Object_Cache::get_pdo_dsn( 'localhost:3306', 'wordpress_test', 'utf8' ) );
-		$this->assertEquals( 'mysql:host=127.0.0.1;port=3306;dbname=wordpress_test;charset=utf8', WP_Object_Cache::get_pdo_dsn( '127.0.0.1:3306', 'wordpress_test', 'utf8' ) );
-		$this->assertEquals( 'mysql:host=db.www.example.com;port=3306;dbname=wordpress_test;charset=utf8', WP_Object_Cache::get_pdo_dsn( 'db.www.example.com:3306', 'wordpress_test', 'utf8' ) );
+		$this->assertEquals( 'mysql:host=localhost;port=3306;dbname=wordpress_test;charset=utf8mb4', WP_Object_Cache::get_pdo_dsn( 'localhost:3306', 'wordpress_test', 'utf8' ) );
+		$this->assertEquals( 'mysql:host=127.0.0.1;port=3306;dbname=wordpress_test;charset=utf8mb4', WP_Object_Cache::get_pdo_dsn( '127.0.0.1:3306', 'wordpress_test', 'utf8' ) );
+		$this->assertEquals( 'mysql:host=db.www.example.com;port=3306;dbname=wordpress_test;charset=utf8mb4', WP_Object_Cache::get_pdo_dsn( 'db.www.example.com:3306', 'wordpress_test', 'utf8' ) );
 	}
 
 	public function test_pdo_dsn_with_socket() {
-		$this->assertEquals( 'mysql:unix_socket=/var/lib/mysql/mysql.sock;dbname=wordpress_test;charset=utf8', WP_Object_Cache::get_pdo_dsn( '/var/lib/mysql/mysql.sock', 'wordpress_test', 'utf8' ) );
+		$this->assertEquals( 'mysql:unix_socket=/var/lib/mysql/mysql.sock;dbname=wordpress_test;charset=utf8mb4', WP_Object_Cache::get_pdo_dsn( '/var/lib/mysql/mysql.sock', 'wordpress_test', 'utf8' ) );
 	}
 
 	public function test_normalize_address_key() {

--- a/tests/phpunit/test-cache.php
+++ b/tests/phpunit/test-cache.php
@@ -1002,7 +1002,7 @@ class CacheTest extends WP_UnitTestCase {
 		$this->altered_value_column = true;
 		$ret = $wpdb->get_results( "SHOW CREATE TABLE `{$table_prefix}lcache_events`" );
 		// @codingStandardsIgnoreEnd
-		$this->assertContains( '`value` varchar(2) DEFAULT NULL,', $ret[0]->{'Create Table'} );
+		$this->assertContains( '`value` varchar(2) COLLATE utf8mb4_unicode_ci DEFAULT NULL,', $ret[0]->{'Create Table'} );
 		$this->cache->set( 'foo', 'basjkfsdfsdksd' );
 	}
 

--- a/wp-lcache.php
+++ b/wp-lcache.php
@@ -32,8 +32,10 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 function wp_lcache_initialize_database_schema() {
 	global $wpdb;
 
-	$events_table = $GLOBALS['table_prefix'] . 'lcache_events';
+	$charset_collate = $wpdb->get_charset_collate();
+
 	// @codingStandardsIgnoreStart
+	$events_table = $GLOBALS['table_prefix'] . 'lcache_events';
 	$wpdb->query( "CREATE TABLE IF NOT EXISTS `{$events_table}` (
 		`event_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 		`pool` varchar(255) NOT NULL DEFAULT '' COMMENT 'PHP process pool that wrote the change.',
@@ -45,15 +47,15 @@ function wp_lcache_initialize_database_schema() {
 		UNIQUE KEY `event_id` (`event_id`),
 		KEY `expiration` (`expiration`),
 		KEY `lookup_miss` (`address`,`event_id`)
-		) ENGINE=InnoDB DEFAULT CHARSET=utf8;" );
+		) {$charset_collate};" );
 
 	$tags_table = $GLOBALS['table_prefix'] . 'lcache_tags';
 	$wpdb->query( "CREATE TABLE IF NOT EXISTS `{$tags_table}` (
-		`tag` varchar(255) NOT NULL DEFAULT '',
-		`address` varchar(255) NOT NULL DEFAULT '',
+		`tag` varchar(191) NOT NULL DEFAULT '',
+		`address` varchar(191) NOT NULL DEFAULT '',
 		PRIMARY KEY (`tag`,`address`),
 		KEY `rewritten_entry` (`address`)
-		) ENGINE=InnoDB DEFAULT CHARSET=utf8;" );
+		) {$charset_collate};" );
 	// @codingStandardsIgnoreEnd
 }
 


### PR DESCRIPTION
* When `DB_CHARSET` is `utf8` WordPress actually [forces it to be `utf8mb4` instead](https://github.com/WordPress/WordPress/blob/2152a6a1ea3db59fcc626fe8129d6fc175e0df66/wp-includes/wp-db.php#L779).
* Use the `$wpdb->get_charset_collate()` helper method used by [SQL statements in core](https://github.com/WordPress/WordPress/blob/2152a6a1ea3db59fcc626fe8129d6fc175e0df66/wp-admin/includes/schema.php#L63).
* Prevent WordPress database error Specified key was too long; max key length is 767 bytes

**Note**
The schema for the `tag` and `address` in the `tags` table also had to be updated to `varchar(191)` to support `utf8mb4` which can have up to 4 bytes per character ( 191 x 4 = 767 ) and therefore would result in an error upon table creation when using InnoDB since they are both primary keys:

```
WordPress database error Specified key was too long; max key length is 767 bytes.
```

cf.
https://developer.wordpress.org/reference/classes/wpdb/determine_charset/
https://developer.wordpress.org/reference/classes/wpdb/get_charset_collate/